### PR TITLE
Pass on original exit code

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -88,7 +88,7 @@ while IFS=$'' read -r matching_file ; do
   matching_files+=("$matching_file")
 done < <(find . -path "./${FILES_PATTERN}")
 
-if [ -n "${BUILDKITE_COMMAND_EXIT_STATUS}" ] && [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
+if [[ ! -z "${BUILDKITE_COMMAND_EXIT_STATUS}" ]] || [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
   if [[ "${#matching_files[@]}" -eq "0" ]]; then
     echo "No files found matching '${FILES_PATTERN}'"
     exit 1
@@ -100,6 +100,6 @@ for file in "${matching_files[@]}"; do
   upload "$TOKEN_VALUE" "$FORMAT" "${file}"
 done
 
-if [ -v "${BUILDKITE_COMMAND_EXIT_STATUS}" ] && [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -ne "0" ]; then
+if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS}" ]]; then
   exit "${BUILDKITE_COMMAND_EXIT_STATUS}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -99,7 +99,3 @@ for file in "${matching_files[@]}"; do
   echo "Uploading '$file'..."
   upload "$TOKEN_VALUE" "$FORMAT" "${file}"
 done
-
-if [[ -n "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]]; then
-  exit "${BUILDKITE_COMMAND_EXIT_STATUS}"
-fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -88,7 +88,7 @@ while IFS=$'' read -r matching_file ; do
   matching_files+=("$matching_file")
 done < <(find . -path "./${FILES_PATTERN}")
 
-if [[ ! -z "${BUILDKITE_COMMAND_EXIT_STATUS}" ]] || [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
+if [[ ! -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
   if [[ "${#matching_files[@]}" -eq "0" ]]; then
     echo "No files found matching '${FILES_PATTERN}'"
     exit 1
@@ -100,6 +100,6 @@ for file in "${matching_files[@]}"; do
   upload "$TOKEN_VALUE" "$FORMAT" "${file}"
 done
 
-if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS}" ]]; then
+if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]]; then
   exit "${BUILDKITE_COMMAND_EXIT_STATUS}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -97,3 +97,7 @@ for file in "${matching_files[@]}"; do
   echo "Uploading '$file'..."
   upload "$TOKEN_VALUE" "$FORMAT" "${file}"
 done
+
+if [ -v "${BUILDKITE_COMMAND_EXIT_STATUS}" ] && [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -ne "0" ]; then
+  exit "${BUILDKITE_COMMAND_EXIT_STATUS}"
+fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -88,7 +88,7 @@ while IFS=$'' read -r matching_file ; do
   matching_files+=("$matching_file")
 done < <(find . -path "./${FILES_PATTERN}")
 
-if [[ ! -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
+if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]]; then
   if [[ "${#matching_files[@]}" -eq "0" ]]; then
     echo "No files found matching '${FILES_PATTERN}'"
     exit 1
@@ -100,6 +100,6 @@ for file in "${matching_files[@]}"; do
   upload "$TOKEN_VALUE" "$FORMAT" "${file}"
 done
 
-if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]]; then
+if [[ -n "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]]; then
   exit "${BUILDKITE_COMMAND_EXIT_STATUS}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -88,9 +88,11 @@ while IFS=$'' read -r matching_file ; do
   matching_files+=("$matching_file")
 done < <(find . -path "./${FILES_PATTERN}")
 
-if [[ "${#matching_files[@]}" -eq "0" ]]; then
-  echo "No files found matching '${FILES_PATTERN}'"
-  exit 1
+if [ -n "${BUILDKITE_COMMAND_EXIT_STATUS}" ] && [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]; then
+  if [[ "${#matching_files[@]}" -eq "0" ]]; then
+    echo "No files found matching '${FILES_PATTERN}'"
+    exit 1
+  fi
 fi
 
 for file in "${matching_files[@]}"; do

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -88,9 +88,9 @@ while IFS=$'' read -r matching_file ; do
   matching_files+=("$matching_file")
 done < <(find . -path "./${FILES_PATTERN}")
 
-if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]]; then
-  if [[ "${#matching_files[@]}" -eq "0" ]]; then
-    echo "No files found matching '${FILES_PATTERN}'"
+if [[ "${#matching_files[@]}" -eq "0" ]]; then
+  echo "No files found matching '${FILES_PATTERN}'"
+  if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]]; then
     exit 1
   fi
 fi


### PR DESCRIPTION
And don't give a "no files found" error on failed builds

Fixes #10