### PR TITLE
Fix typo: format should either be junit or json

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -79,7 +79,7 @@ if [[ -z "${FILES_PATTERN}" ]]; then
 fi
 
 if [[ -z "${FORMAT}" ]]; then
-  echo "Missing file format 'format'. Possible values: 'junit', 'xml'"
+  echo "Missing file format 'format'. Possible values: 'junit', 'json'"
   exit 1
 fi
 

--- a/tests/pre-exit-errors.bats
+++ b/tests/pre-exit-errors.bats
@@ -34,7 +34,7 @@ setup() {
   run "$PWD/hooks/pre-exit"
 
   assert_failure
-  assert_output --partial "Missing file format 'format'. Possible values: 'junit', 'xml'"
+  assert_output --partial "Missing file format 'format'. Possible values: 'junit', 'json'"
 }
 
 @test "Errors if no file is found" {


### PR DESCRIPTION
We only accept `junit`, `json`, or `websocket`, so I think the `xml` is probably a typo.