### PR TITLE
feat: allow option to skip uploads altogether

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ steps:
 * `api-token-env-name` — Optional — String — Name of the environment variable that contains the Test Analytics API token. Default value: `"BUILDKITE_ANALYTICS_TOKEN"`
 * `timeout` — Optional — Number — Maximum number of seconds to wait for each file to upload before timing out. Default value: `30`
 * `debug` — Optional — Boolean — Print debug information to the build output. Default value: `false`. Can also be enabled with the environment variable `BUILDKITE_ANALYTICS_DEBUG_ENABLED`.
+* `skip` — Optional — Boolean — Skip the upload altogether. Default value: `false`
 
 <!-- * `artifact` — Optional — Boolean — Search for the files as build artifacts. Default value: `false` -->
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -11,10 +11,16 @@ TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 
 DEBUG="false"
 
+SKIP="false"
+
 if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG:-}" =~ ^(true|on|1|always)$ ]]; then
   DEBUG="true"
 elif [[ "${BUILDKITE_ANALYTICS_DEBUG_ENABLED:-}" =~ ^(true|on|1|always)$ ]]; then
   DEBUG="true"
+fi
+
+if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_SKIP:-}" =~ ^(true|on|1|always)$ ]]; then
+  SKIP="true"
 fi
 
 TOKEN_VALUE=$(eval "echo \${$TOKEN_ENV_NAME:-}")
@@ -67,6 +73,11 @@ upload() {
 
   curl "${curl_args[@]}" || true
 }
+
+if [[ "$SKIP" == "true" ]]; then
+  echo "Skipping upload since 'skip' set to true"
+  exit 0
+fi
 
 if [[ -z "${TOKEN_VALUE}" ]]; then
   echo "Missing $TOKEN_ENV_NAME environment variable"

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,6 +18,8 @@ configuration:
       type: boolean
     timeout:
       type: integer
+    skip:
+      type: boolean
   required:
     - files
     - format

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -130,3 +130,12 @@ setup() {
   assert_success
   assert_output --partial "curl success"
 }
+
+@test "skip is configurable" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_SKIP='true'
+
+  run "$PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output "Skipping upload since 'skip' set to true"
+}


### PR DESCRIPTION
There can be some cases where test results do not need to be uploaded. Allowing for a skip parameter to skip everything altogether.