### PR TITLE
added skip option to allow skipping of uploading test artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ steps:
 * `api-token-env-name` — Optional — String — Name of the environment variable that contains the Test Analytics API token. Default value: `"BUILDKITE_ANALYTICS_TOKEN"`
 * `timeout` — Optional — Number — Maximum number of seconds to wait for each file to upload before timing out. Default value: `30`
 * `debug` — Optional — Boolean — Print debug information to the build output. Default value: `false`. Can also be enabled with the environment variable `BUILDKITE_ANALYTICS_DEBUG_ENABLED`.
+* `skip` — Optional — Boolean — Skips uploading files to buildkite analytics. Default value: `false`.
 
 <!-- * `artifact` — Optional — Boolean — Search for the files as build artifacts. Default value: `false` -->
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -34,7 +34,7 @@ PLUGIN_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "")
 # TODO: Add build annotation on failure
 upload() {
 
-  if [[ "$DEBUG" == "true" ]]; then
+  if [[ "$SKIP" == "true" ]]; then
     echo "skipping test-collector plugin"
     return 0
   fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -11,10 +11,16 @@ TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 
 DEBUG="false"
 
+SKIP="false"
+
 if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG:-}" =~ ^(true|on|1|always)$ ]]; then
   DEBUG="true"
 elif [[ "${BUILDKITE_ANALYTICS_DEBUG_ENABLED:-}" =~ ^(true|on|1|always)$ ]]; then
   DEBUG="true"
+fi
+
+if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_SKIP:-}" =~ ^(true|on|1|always)$ ]]; then
+  SKIP="true"
 fi
 
 TOKEN_VALUE=$(eval "echo \${$TOKEN_ENV_NAME:-}")
@@ -27,6 +33,12 @@ PLUGIN_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "")
 #
 # TODO: Add build annotation on failure
 upload() {
+
+  if [[ "$DEBUG" == "true" ]]; then
+    echo "skipping test-collector plugin"
+    return 0
+  fi
+
   local file="$3"
 
   local curl_args=(

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -36,6 +36,15 @@ setup() {
   assert_output --partial "curl success"
 }
 
+@test "Skips uploading files" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_SKIP="true"
+
+  run "$PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial "skipping test-collector plugin"
+}
+
 @test "Uploads multiple file" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
 


### PR DESCRIPTION
The goal of this change is to be able to skip uploading analytics depending on whatever conditions matter for you.

In our repo we plan on adding this snipit of code to our "pre-command" step
```sh
echo "--- Determine if we should upload to buildkite analytics"
export CAMPSPOT_SKIP_BUILDKITE_ANALYTICS="true"
if [[ "$BUILDKITE_BRANCH" == "development" ]]; then
  CAMPSPOT_SKIP_BUILDKITE_ANALYTICS="false"
fi
```

Then our pipeline step can look like the following
```yml
- name: "Unit Tests :junit:"
  command: .buildkite/build-scripts/java-unit-test.sh
  parallelism: 2
  artifact_paths:
    - 'jacoco/**/*'
    - 'surefire-reports/**/*'
    - 'logs/*'
  plugins:
    - docker-compose#v3.9.0:
        run: app
        config: docker-compose.buildkite.yml
        pull-retries: 1
        dependencies: false
    - test-collector#v1.0.0:
        files: "surefire-reports/*.xml"
        format: "junit"
        api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT"
        skip: ${CAMPSPOT_SKIP_BUILDKITE_ANALYTICS}
```