### PR TITLE
Bash 4.3 compatibility

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -105,7 +105,7 @@ done < <("${FIND_CMD[@]}" . -path "./${FILES_PATTERN}")
 
 if [[ "${#matching_files[@]}" -eq "0" ]]; then
   echo "No files found matching '${FILES_PATTERN}'"
-  if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]]; then
+  if [[ "${BUILDKITE_COMMAND_EXIT_STATUS:-0}" -eq "0" ]]; then
     exit 1
   fi
 else

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -108,11 +108,12 @@ if [[ "${#matching_files[@]}" -eq "0" ]]; then
   if [[ -z "${BUILDKITE_COMMAND_EXIT_STATUS+x}" ]] || [[ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq "0" ]]; then
     exit 1
   fi
+else
+  # needs to be part of else for bash4.3 compatibility
+  for file in "${matching_files[@]}"; do
+    echo "Uploading '$file'..."
+    if ! upload "$TOKEN_VALUE" "$FORMAT" "${file}"; then
+      echo "Error uploading, will continue"
+    fi
+  done
 fi
-
-for file in "${matching_files[@]}"; do
-  echo "Uploading '$file'..."
-  if ! upload "$TOKEN_VALUE" "$FORMAT" "${file}"; then
-    echo "Error uploading, will continue"
-  fi
-done


### PR DESCRIPTION
Minor change to the code logic to make it compatible with Bash version 4.3 that handles empty arrays as undefined variables.

If I create a plugin tester that uses Bash 4.3 the following test fails:
```
Keeps command error if no file is found
# (in test file tests/pre-exit-errors.bats, line 58)
#   `assert_success' failed
#
# -- command failed --
# status : 1
# output (2 lines):
#   No files found matching 'file.xml'
#   /mnt/hooks/pre-exit: line 113: matching_files[@]: unbound variable
# --
#
```

Closes #33 