### PR TITLE
Follow symlink feature fix

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -95,7 +95,7 @@ fi
 
 FIND_CMD=(find)
 
-if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_LINKS:-}" =~ ^(true|on|1|always)$ ]]; then
+if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS:-}" =~ ^(true|on|1|always)$ ]]; then
   FIND_CMD+=('-L')
 fi
 

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -124,7 +124,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 }
 
 @test "Follow links option enabled adds find option" {
-  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_LINKS='true'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='true'
 
   stub find "-L . -path \* : echo './tests/fixtures/junit-1.xml'"
   stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
@@ -139,7 +139,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 }
 
 @test "Follow links option disabled does not add find option" {
-  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_LINKS='false'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='false'
 
   stub find ". -path \* : echo './tests/fixtures/junit-1.xml'"
   stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"


### PR DESCRIPTION
As noted in #41 the `follow-symlink` option does not work as the variable name used in the code does not match.

Without this fix, the feature is not usable :(