### PR TITLE
feat: Creating annotation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Maximum number of seconds to wait for each file to upload before timing out.
 
 Default value: `30`
 
-#### `annotate-report`(boolean)
+#### `annotation-link`(boolean)
 
-Adds an annotation to with a link to the uploaded report.
+Adds an annotation to the build run with a link to the uploaded report.
 
 Default value: `false`
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Maximum number of seconds to wait for each file to upload before timing out.
 
 Default value: `30`
 
+#### `annotate-report`(boolean)
+
+Adds an annotation to with a link to the uploaded report.
+
+Default value: `false`
+
 ## Examples
 
 ### Upload a JUnit file

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -52,7 +52,7 @@ annotation-link() {
   REPORT_COUNT=1
   if [ ${#REPORT_URLS[@]} -gt 0 ]; then
     echo "Got ${#REPORT_URLS[@]} report URLs."
-    for URL in "${!REPORT_URLS[@]}"; do
+    for URL in "${REPORT_URLS[@]}"; do
       REPORTS+="- [Report #${REPORT_COUNT}](${URL})\n"
       REPORT_COUNT=$((REPORT_COUNT + 1))
     done

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,7 +5,7 @@ TOKEN_ENV_NAME="${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME:-BUILDKITE_
 FORMAT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT:-}"
 TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 BASE_PATH="${BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH:-.}"
-ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT:-false}"
+ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK:-false}"
 REPORT_URLS_FILE=$(mktemp)
 CURL_RESP_FILE="${CURL_RESP_FILE:-response.json}"
 DEBUG="false"
@@ -44,46 +44,50 @@ if [[ -z "${FORMAT}" ]]; then
 fi
 
 # Creates the annotations with all the report URLs
-annotate-report() {
-  [ "${ANNOTATE}" != "true" ] && return
+annotation-link() {
   local json_file="$1"
   mapfile -t REPORT_URLS < <(sort "${json_file}" | uniq)
 
   local REPORTS=""
   REPORT_COUNT=1
-  for URL in "${!REPORT_URLS[@]}"; do
-    REPORTS+="- [Report #${REPORT_COUNT}](${URL})\n"
-    REPORT_COUNT=$((REPORT_COUNT + 1))
-  done
+  if [ ${#REPORT_URLS[@]} -gt 0 ]; then
+    echo "Got ${#REPORT_URLS[@]} report URLs."
+    for URL in "${!REPORT_URLS[@]}"; do
+      REPORTS+="- [Report #${REPORT_COUNT}](${URL})\n"
+      REPORT_COUNT=$((REPORT_COUNT + 1))
+    done
 
-  buildkite-agent annotate --style info --context "test-collector" "Check the test report(s) here: \n\n${REPORTS}"
+    buildkite-agent annotate --style info --context "test-collector" "Check the test report(s) here: \n\n${REPORTS}"
+  else
+    echo "There are no report URLs to annotate."
+  fi
 }
 
 # Saves the build with the report URL
 save-report-url() {
-  [ "${ANNOTATE}" != "true" ] && return
-  
   local json_file="$1"
   local report_url
 
-  if [[ ! -f "${json_file}" ]]; then
-    echo "Failed to upload test results from $json_file. File not found."
+  if [ ! -f "${json_file}" ]; then
+    echo "Could not get the tests report URL from $json_file. File not found."
     return
   fi
   # Could be easier with jq, but we don't want to require it
-  if command -v jq >/dev/null; then
+  if which jq >/dev/null; then
+      echo "Using jq to parse the report URL"
      report_url=$(jq -r '.run_url' "${json_file}")
   else
+      echo "Not using jq to parse the report URL"
      report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
   fi
 
-  if [[ "$report_url" == "" ]]; then
-    echo "Failed to upload test results from $json_file"
+  if [ "$report_url" == "null" ]; then
+    echo "Could not get the tests report URL from $json_file. 'run_url' property not found."
     return
   fi
 
-  echo "Saving test report URL to $REPORT_URLS_FILE"
-  echo "$report_url" > "$REPORT_URLS_FILE"
+  echo "Saving tests report URL to $REPORT_URLS_FILE"
+  echo "$report_url" >> "$REPORT_URLS_FILE"
 }
 
 # Uploads files to the Test Analytics API
@@ -159,14 +163,15 @@ find_and_upload() {
       if ! upload "$TOKEN_VALUE" "$FORMAT" "${file}"; then
         echo "Error uploading, will continue"
       fi
-      save-report-url "${CURL_RESP_FILE}"
+      if [ "${ANNOTATE}" != "false" ]; then
+        save-report-url "${CURL_RESP_FILE}"
+      fi
     done
   fi
 }
 
 if [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES:-}" ]; then
   find_and_upload "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES}"
-  annotate-report "${REPORT_URLS_FILE}"
 elif [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES_0:-}" ]; then
   prefix="BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES"
   parameter="${prefix}_0"
@@ -179,9 +184,11 @@ elif [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES_0:-}" ]; then
       i=$((i+1))
       parameter="${prefix}_${i}"
     done
-    annotate-report "${REPORT_URLS_FILE}"
   fi
 else
   echo "Missing file upload pattern 'files', e.g. 'junit-*.xml'"
   exit 1
+fi
+if [ "${ANNOTATE}" != "false" ]; then
+  annotation-link "${REPORT_URLS_FILE}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -124,7 +124,11 @@ upload() {
     curl_args+=("--form" "run_env[version]=$PLUGIN_VERSION")
   fi
 
-  curl_args+=("${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL:-https://analytics-api.buildkite.com/v1/uploads}" "-o" "${CURL_RESP_FILE}")
+  if [[ "$ANNOTATE" != "false" ]]; then
+    curl_args+=("-o" "${CURL_RESP_FILE}")
+  fi
+
+  curl_args+=("${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL:-https://analytics-api.buildkite.com/v1/uploads}")
 
   # Print debugging output before we add the token, so it doesn't ever get
   # printed to output
@@ -163,7 +167,7 @@ find_and_upload() {
       if ! upload "$TOKEN_VALUE" "$FORMAT" "${file}"; then
         echo "Error uploading, will continue"
       fi
-      if [ "${ANNOTATE}" != "false" ]; then
+      if [[ "$ANNOTATE" != "false" ]]; then
         save-report-url "${CURL_RESP_FILE}"
       fi
     done
@@ -189,6 +193,6 @@ else
   echo "Missing file upload pattern 'files', e.g. 'junit-*.xml'"
   exit 1
 fi
-if [ "${ANNOTATE}" != "false" ]; then
+if [ "$ANNOTATE" != "false" ]; then
   annotation-link "${REPORT_URLS_FILE}"
 fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -47,7 +47,7 @@ fi
 annotate-report() {
   [ "${ANNOTATE}" != "true" ] && return
   local json_file="$1"
-  mapfile -t REPORT_URLS < <(sort $json_file | uniq)
+  mapfile -t REPORT_URLS < <(sort "${json_file}" | uniq)
 
   local REPORTS=""
   REPORT_COUNT=1

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -6,6 +6,7 @@ FORMAT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT:-}"
 TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 BASE_PATH="${BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH:-.}"
 ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT:-false}"
+REPORT_URLS_FILE=$(mktemp)
 CURL_RESP_FILE="${CURL_RESP_FILE:-response.json}"
 DEBUG="false"
 
@@ -42,19 +43,47 @@ if [[ -z "${FORMAT}" ]]; then
   exit 1
 fi
 
-# Annotates the build with the report URL
+# Creates the annotations with all the report URLs
 annotate-report() {
+  [ "${ANNOTATE}" != "true" ] && return
+  local json_file="$1"
+  mapfile -t REPORT_URLS < <(sort $json_file | uniq)
+
+  local REPORTS=""
+  REPORT_COUNT=1
+  for URL in "${!REPORT_URLS[@]}"; do
+    REPORTS+="- [Report #${REPORT_COUNT}](${URL})\n"
+    REPORT_COUNT=$((REPORT_COUNT + 1))
+  done
+
+  buildkite-agent annotate --style info --context "test-collector" "Check the test report(s) here: \n\n${REPORTS}"
+}
+
+# Saves the build with the report URL
+save-report-url() {
+  [ "${ANNOTATE}" != "true" ] && return
+  
   local json_file="$1"
   local report_url
+
+  if [[ ! -f "${json_file}" ]]; then
+    echo "Failed to upload test results from $json_file. File not found."
+    return
+  fi
   # Could be easier with jq, but we don't want to require it
-  report_url=$(< "$json_file" tr '{' '\n' | tr , '\n' | tr '}' '\n' | grep 'run_url' | sed -r 's/^[^:]*:(.*)$/\1/' | sed 's/"//g')
+  if command -v jq >/dev/null; then
+     report_url=$(jq -r '.run_url' "${json_file}")
+  else
+     report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
+  fi
 
   if [[ "$report_url" == "" ]]; then
     echo "Failed to upload test results from $json_file"
     return
   fi
 
-  buildkite-agent annotate --style info --context "test-collector" "Check the test report [here]($report_url)."
+  echo "Saving test report URL to $REPORT_URLS_FILE"
+  echo "$report_url" > "$REPORT_URLS_FILE"
 }
 
 # Uploads files to the Test Analytics API
@@ -91,7 +120,7 @@ upload() {
     curl_args+=("--form" "run_env[version]=$PLUGIN_VERSION")
   fi
 
-  curl_args+=("${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL:-https://analytics-api.buildkite.com/v1/uploads}")
+  curl_args+=("${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL:-https://analytics-api.buildkite.com/v1/uploads}" "-o" "${CURL_RESP_FILE}")
 
   # Print debugging output before we add the token, so it doesn't ever get
   # printed to output
@@ -99,10 +128,9 @@ upload() {
     echo curl "${curl_args[@]}"
   fi
 
-  curl_args+=("-H" "Authorization: Token token=\"$TOKEN_VALUE\"" "-o" "${CURL_RESP_FILE}")
+  curl_args+=("-H" "Authorization: Token token=\"$TOKEN_VALUE\"")
 
   curl "${curl_args[@]}"
-  [ "${ANNOTATE}" == "true" ] && annotate-report "${CURL_RESP_FILE}"
 }
 
 # Runs the whole plugin logic for a particular find pattern
@@ -131,12 +159,14 @@ find_and_upload() {
       if ! upload "$TOKEN_VALUE" "$FORMAT" "${file}"; then
         echo "Error uploading, will continue"
       fi
+      save-report-url "${CURL_RESP_FILE}"
     done
   fi
 }
 
 if [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES:-}" ]; then
   find_and_upload "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES}"
+  annotate-report "${REPORT_URLS_FILE}"
 elif [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES_0:-}" ]; then
   prefix="BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES"
   parameter="${prefix}_0"
@@ -149,6 +179,7 @@ elif [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES_0:-}" ]; then
       i=$((i+1))
       parameter="${prefix}_${i}"
     done
+    annotate-report "${REPORT_URLS_FILE}"
   fi
 else
   echo "Missing file upload pattern 'files', e.g. 'junit-*.xml'"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,6 +5,8 @@ TOKEN_ENV_NAME="${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME:-BUILDKITE_
 FORMAT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT:-}"
 TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 BASE_PATH="${BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH:-.}"
+ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT:-false}"
+CURL_RESP_FILE="${CURL_RESP_FILE:-response.json}"
 DEBUG="false"
 
 if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG:-}" =~ ^(true|on|1|always)$ ]]; then
@@ -39,6 +41,21 @@ if [[ -z "${FORMAT}" ]]; then
   echo "Missing file format 'format'. Possible values: 'junit', 'json'"
   exit 1
 fi
+
+# Annotates the build with the report URL
+annotate-report() {
+  local json_file="$1"
+  local report_url
+  # Could be easier with jq, but we don't want to require it
+  report_url=$(< "$json_file" tr '{' '\n' | tr , '\n' | tr '}' '\n' | grep 'run_url' | sed -r 's/^[^:]*:(.*)$/\1/' | sed 's/"//g')
+
+  if [[ "$report_url" == "" ]]; then
+    echo "Failed to upload test results from $json_file"
+    return
+  fi
+
+  buildkite-agent annotate --style info --context "test-collector" "Check the test report [here]($report_url)."
+}
 
 # Uploads files to the Test Analytics API
 #
@@ -82,9 +99,10 @@ upload() {
     echo curl "${curl_args[@]}"
   fi
 
-  curl_args+=("-H" "Authorization: Token token=\"$TOKEN_VALUE\"")
+  curl_args+=("-H" "Authorization: Token token=\"$TOKEN_VALUE\"" "-o" "${CURL_RESP_FILE}")
 
   curl "${curl_args[@]}"
+  [ "${ANNOTATE}" == "true" ] && annotate-report "${CURL_RESP_FILE}"
 }
 
 # Runs the whole plugin logic for a particular find pattern

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,7 +5,7 @@ TOKEN_ENV_NAME="${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME:-BUILDKITE_
 FORMAT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT:-}"
 TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
 BASE_PATH="${BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH:-.}"
-ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK:-false}"
+ANNOTATE="${BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATION_LINK:-false}"
 REPORT_URLS_FILE=$(mktemp)
 CURL_RESP_FILE="${CURL_RESP_FILE:-response.json}"
 DEBUG="false"
@@ -75,10 +75,10 @@ save-report-url() {
   # Could be easier with jq, but we don't want to require it
   if which jq >/dev/null; then
       echo "Using jq to parse the report URL"
-     report_url=$(jq -r '.run_url' "${json_file}")
+      report_url=$(jq -r '.run_url' "${json_file}")
   else
       echo "Not using jq to parse the report URL"
-     report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
+      report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
   fi
 
   if [ "$report_url" == "null" ]; then
@@ -86,7 +86,6 @@ save-report-url() {
     return
   fi
 
-  echo "Saving tests report URL to $REPORT_URLS_FILE"
   echo "$report_url" >> "$REPORT_URLS_FILE"
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -31,6 +31,8 @@ configuration:
         - junit
     timeout:
       type: integer
+    annotate-report:
+      type: boolean
   required:
     - files
     - format

--- a/plugin.yml
+++ b/plugin.yml
@@ -31,7 +31,7 @@ configuration:
         - junit
     timeout:
       type: integer
-    annotate-report:
+    annotation-link:
       type: boolean
   required:
     - files

--- a/tests/branches.bats
+++ b/tests/branches.bats
@@ -4,7 +4,7 @@
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
+CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
 
 setup() {
   load "$BATS_PLUGIN_PATH/load.bash"

--- a/tests/branches.bats
+++ b/tests/branches.bats
@@ -4,7 +4,7 @@
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
+CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
 
 setup() {
   load "$BATS_PLUGIN_PATH/load.bash"

--- a/tests/exclude-branches.bats
+++ b/tests/exclude-branches.bats
@@ -4,7 +4,7 @@
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
+CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
 
 setup() {
   load "$BATS_PLUGIN_PATH/load.bash"

--- a/tests/exclude-branches.bats
+++ b/tests/exclude-branches.bats
@@ -4,7 +4,7 @@
 # export CURL_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
-CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
+CURL_DEFAULT_STUB='\* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \* \*'
 
 setup() {
   load "$BATS_PLUGIN_PATH/load.bash"

--- a/tests/fixtures/response.json
+++ b/tests/fixtures/response.json
@@ -1,0 +1,1 @@
+{"id":"0","run_id":"0","queued":110,"skipped":0,"errors":[],"run_url":"https://buildkite.com/organizations/allurion/analytics/suites/collector-test/runs/0"}

--- a/tests/fixtures/response.json
+++ b/tests/fixtures/response.json
@@ -1,1 +1,1 @@
-{"id":"0","run_id":"0","queued":110,"skipped":0,"errors":[],"run_url":"https://buildkite.com/organizations/allurion/analytics/suites/collector-test/runs/0"}
+{"id":"0","run_id":"0","queued":110,"skipped":0,"errors":[],"run_url":"https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/0"}

--- a/tests/fixtures/response_no_url.json
+++ b/tests/fixtures/response_no_url.json
@@ -1,0 +1,1 @@
+{"id":"0","run_id":"0","queued":110,"skipped":0,"errors":[],"report_url":"https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/0"}

--- a/tests/pre-exit-report-link.bats
+++ b/tests/pre-exit-report-link.bats
@@ -95,7 +95,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
     "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/1" \
     "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/2" \
     "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/1"
-  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success' with params \${6}"
   
 
   run "$PWD/hooks/pre-exit"
@@ -106,7 +106,9 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   assert_output --partial "curl success 1"
   assert_output --partial "curl success 3"
   assert_output --partial "Got 2 report URLs."
-  assert_output --partial "annotation success"
+  assert_output --partial "- [Report #1](https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/1)"
+  assert_output --partial "- [Report #2](https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/2)"
+  refute_output --partial "- [Report #3]"
 
   unstub buildkite-agent
   unstub jq

--- a/tests/pre-exit-report-link.bats
+++ b/tests/pre-exit-report-link.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+
+# To debug stubs, uncomment these lines:
+# export CURL_STUB_DEBUG=/dev/tty
+# export GIT_STUB_DEBUG=/dev/tty
+
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME=""
+
+  # Config
+  export BUILDKITE_ANALYTICS_TOKEN='a-secret-analytics-token'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-1.xml'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT='junit'
+  # Build env
+  export BUILDKITE_BUILD_ID="an-id"
+  export BUILDKITE_BUILD_URL="https://url.com/"
+  export BUILDKITE_BRANCH="a-branch"
+  export BUILDKITE_COMMIT="a-commit"
+  export BUILDKITE_BUILD_NUMBER="123"
+  export BUILDKITE_JOB_ID="321"
+  export BUILDKITE_MESSAGE="A message"
+}
+
+COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \*'
+
+@test "Annotates report link with jq" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  export CURL_RESP_FILE="./tests/fixtures/response.json"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub buildkite-agent
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "Using jq"
+  assert_output --partial "annotation success"
+}
+
+@test "Annotates report link without jq" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  export CURL_RESP_FILE="./tests/fixtures/response.json"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  stub which "jq : exit 1"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub which
+  unstub buildkite-agent
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "Not using jq"
+  assert_output --partial "annotation success"
+}
+
+@test "Annotates report link from multiple file and same report URLs" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  export CURL_RESP_FILE="./tests/fixtures/response.json"
+
+  stub curl \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 3'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+
+  run "$PWD/hooks/pre-exit"
+
+  unstub buildkite-agent
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "Uploading './tests/fixtures/junit-2.xml'..."
+  assert_output --partial "curl success 1"
+  assert_output --partial "curl success 3"
+  assert_output --partial "Got 1 report URLs."
+  assert_output --partial "annotation success"
+}
+
+@test "Annotates report link from multiple file and different report URLs" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  export CURL_RESP_FILE="./tests/fixtures/response.json"
+
+  stub curl \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 3'"
+  stub jq \
+    "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/1" \
+    "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/2" \
+    "-r '.run_url' \* : echo https://buildkite.com/organizations/example/analytics/suites/collector-test/runs/1"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+
+  run "$PWD/hooks/pre-exit"
+
+  unstub buildkite-agent
+  unstub jq
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "Uploading './tests/fixtures/junit-3.xml'..."
+  assert_output --partial "curl success 1"
+  assert_output --partial "curl success 3"
+  assert_output --partial "Got 2 report URLs."
+  assert_output --partial "annotation success"
+}
+@test "Annotates report link absorbs empty file error" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "Could not get the tests report URL from response.json. File not found."
+}
+
+@test "No annotation when url property on json response is missing" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_LINK="true"
+  export CURL_RESP_FILE="./tests/fixtures/response_no_url.json"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "'run_url' property not found"
+  assert_output --partial "There are no report URLs to annotate"
+}

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -25,7 +25,7 @@ setup() {
 COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \*'
 
 @test "Uploads a file" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -40,8 +40,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -59,7 +59,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -77,8 +77,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -94,7 +94,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug true prints the curl info w/o token" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -109,7 +109,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug env var true prints the curl info w/o token" {
   export BUILDKITE_ANALYTICS_DEBUG_ENABLED="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with  with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with  with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -123,7 +123,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug false does not print the curl info" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="false"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -136,7 +136,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Timeout is configurable" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT='999'
 
-  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -148,7 +148,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
 @test "Git available sends plugin version" {
   stub git "rev-parse --short HEAD : echo 'some-commit-id'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -164,7 +164,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='true'
 
   stub find "-L . -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -179,7 +179,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='false'
 
   stub find ". -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -193,7 +193,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "API can change" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL='https://test-api.example.com/v2'
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo \"curl success against \${29}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo \"curl success against \${29}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -209,7 +209,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH='/test'
 
   stub find "/test -path /test/\*\*/\*/junit-1.xml : echo '/test/tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
 
   run "${PWD}/hooks/pre-exit"
 
@@ -221,7 +221,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 }
 
 @test "Absorb curl failures" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : exit 10"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : exit 10"
 
   run "$PWD/hooks/pre-exit"
 
@@ -235,7 +235,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Annotates report" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
   export CURL_RESP_FILE="./tests/fixtures/response.json"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
   stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
   
   run "$PWD/hooks/pre-exit"
@@ -250,7 +250,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
 @test "Annotates report absorbs empty file error" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
   stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
   
   run "$PWD/hooks/pre-exit"

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -25,7 +25,7 @@ setup() {
 COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \*'
 
 @test "Uploads a file" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -40,9 +40,9 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 3'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 2'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 3'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -62,7 +62,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -80,8 +80,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 2'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -97,7 +97,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug true prints the curl info w/o token" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -112,7 +112,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug env var true prints the curl info w/o token" {
   export BUILDKITE_ANALYTICS_DEBUG_ENABLED="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with  with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with  with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -126,7 +126,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug false does not print the curl info" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="false"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -139,7 +139,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Timeout is configurable" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT='999'
 
-  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -151,7 +151,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
 @test "Git available sends plugin version" {
   stub git "rev-parse --short HEAD : echo 'some-commit-id'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* \* \* -H \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -167,7 +167,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='true'
 
   stub find "-L . -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -182,7 +182,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='false'
 
   stub find ". -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -196,7 +196,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "API can change" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL='https://test-api.example.com/v2'
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo \"curl success against \${29}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo \"curl success against \${29}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -212,7 +212,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH='/test'
 
   stub find "/test -path /test/\*\*/\*/junit-1.xml : echo '/test/tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
 
   run "${PWD}/hooks/pre-exit"
 
@@ -224,7 +224,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 }
 
 @test "Absorb curl failures" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : exit 10"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : exit 10"
 
   run "$PWD/hooks/pre-exit"
 

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -41,7 +41,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
   stub curl \
     "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 2'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success 3'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -50,8 +51,10 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   assert_success
   assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
   assert_output --partial "Uploading './tests/fixtures/junit-2.xml'..."
+  assert_output --partial "Uploading './tests/fixtures/junit-3.xml'..."
   assert_output --partial "curl success 1"
   assert_output --partial "curl success 2"
+  assert_output --partial "curl success 3"
 }
 
 @test "Single file pattern through array" {
@@ -230,35 +233,4 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   assert_success
   assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
   assert_output --partial "Error uploading, will continue"
-}
-
-@test "Annotates report" {
-  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
-  export CURL_RESP_FILE="./tests/fixtures/response.json"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
-  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
-  
-  run "$PWD/hooks/pre-exit"
-
-  unstub curl
-
-  assert_success
-  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
-  assert_output --partial "curl success"
-  assert_output --partial "annotation success"
-}
-
-@test "Annotates report absorbs empty file error" {
-  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* \* \* -H \* : echo 'curl success'"
-  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
-  
-  run "$PWD/hooks/pre-exit"
-
-  unstub curl
-
-  assert_success
-  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
-  assert_output --partial "curl success"
-  assert_output --partial "Failed to upload test results from response.json"
 }

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -25,7 +25,7 @@ setup() {
 COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \* --form \*'
 
 @test "Uploads a file" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -40,8 +40,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES='**/*/junit-*.xml'
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 2'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -59,7 +59,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -77,8 +77,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unset BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES
 
   stub curl \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 1'" \
-    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success 2'"
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 1'" \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success 2'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -94,7 +94,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug true prints the curl info w/o token" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -109,7 +109,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug env var true prints the curl info w/o token" {
   export BUILDKITE_ANALYTICS_DEBUG_ENABLED="true"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with  with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with  with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -123,7 +123,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Debug false does not print the curl info" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="false"
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -136,7 +136,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "Timeout is configurable" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT='999'
 
-  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 999 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -148,7 +148,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
 @test "Git available sends plugin version" {
   stub git "rev-parse --short HEAD : echo 'some-commit-id'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* : echo \"curl success with \${30}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form \* \* -H \* \* \* : echo \"curl success with \${30}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -164,7 +164,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='true'
 
   stub find "-L . -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -179,7 +179,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_FOLLOW_SYMLINKS='false'
 
   stub find ". -path \* : echo './tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "$PWD/hooks/pre-exit"
 
@@ -193,7 +193,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 @test "API can change" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_API_URL='https://test-api.example.com/v2'
 
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo \"curl success against \${29}\""
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo \"curl success against \${29}\""
 
   run "$PWD/hooks/pre-exit"
 
@@ -209,7 +209,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_BASE_PATH='/test'
 
   stub find "/test -path /test/\*\*/\*/junit-1.xml : echo '/test/tests/fixtures/junit-1.xml'"
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : echo 'curl success'"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
 
   run "${PWD}/hooks/pre-exit"
 
@@ -221,7 +221,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 }
 
 @test "Absorb curl failures" {
-  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* : exit 10"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : exit 10"
 
   run "$PWD/hooks/pre-exit"
 
@@ -230,4 +230,35 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   assert_success
   assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
   assert_output --partial "Error uploading, will continue"
+}
+
+@test "Annotates report" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
+  export CURL_RESP_FILE="./tests/fixtures/response.json"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "annotation success"
+}
+
+@test "Annotates report absorbs empty file error" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_ANNOTATE_REPORT="true"
+  stub curl "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} \* -H \* \* \* : echo 'curl success'"
+  stub buildkite-agent "annotate --style info --context \"test-collector\"  \* : echo 'annotation success'"
+  
+  run "$PWD/hooks/pre-exit"
+
+  unstub curl
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+  assert_output --partial "Failed to upload test results from response.json"
 }


### PR DESCRIPTION
## What it does?
It creates a new property called `annotate-report` that makes the plugin add an annotation to the build wit ha link to the Test Analytics run report when enabled.

## How can I test it?
Use the plugin from this repo and branch, and enable the annotation property:

i.e.:
```yaml
steps:
  - label: "🔨 Test"
    command: "make test"
    plugins:
      - ingcsmoreno/test-collector-buildkite-plugin#feat/smoreno/annotations:
          files: "test/junit-*.xml"
          format: "junit"
          annotate-report: true
```

## Extra Comments
I'm leaving this property dissable by default to backward compatible with its expected behavior.