### PR TITLE
Fix artifact download example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ steps:
   - wait
 
   - label: "🔍 Test Analytics"
-    command: buildkite-agent artifact download tests-*.xml
+    command: buildkite-agent artifact download "tests-*.xml" .
     plugins:
       - test-collector#v1.10.0:
           files: "tests-*.xml"


### PR DESCRIPTION
As is, the example code doesn't work.  It fails with the error `Missing artifact download path` due to the missing trailing `.`

Additionally, per [the docs](https://buildkite.com/docs/agent/v3/cli-artifact#downloading-artifacts-description):

> You need to ensure that your search query is surrounded by quotes if using a wild card as the built-in shell path globbing will expand the wild card and break the query.