### PR TITLE
Surround env vars in quotes to support parentheses

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -107,22 +107,22 @@ upload() {
     "--form" "format=${format}"
     "--form" "data=@\"$file\""
     "--form" "run_env[CI]=buildkite"
-    "--form" "run_env[key]=$BUILDKITE_BUILD_ID"
-    "--form" "run_env[url]=$BUILDKITE_BUILD_URL"
-    "--form" "run_env[branch]=$BUILDKITE_BRANCH"
-    "--form" "run_env[commit_sha]=$BUILDKITE_COMMIT"
-    "--form" "run_env[number]=$BUILDKITE_BUILD_NUMBER"
-    "--form" "run_env[job_id]=$BUILDKITE_JOB_ID"
-    "--form" "run_env[message]=$BUILDKITE_MESSAGE"
+    "--form" "run_env[key]=\"$BUILDKITE_BUILD_ID\""
+    "--form" "run_env[url]=\"$BUILDKITE_BUILD_URL\""
+    "--form" "run_env[branch]=\"$BUILDKITE_BRANCH\""
+    "--form" "run_env[commit_sha]=\"$BUILDKITE_COMMIT\""
+    "--form" "run_env[number]=\"$BUILDKITE_BUILD_NUMBER\""
+    "--form" "run_env[job_id]=\"$BUILDKITE_JOB_ID\""
+    "--form" "run_env[message]=\"$BUILDKITE_MESSAGE\""
     "--form" "run_env[collector]=test-collector-buildkite-plugin"
   )
 
   if [[ "$DEBUG" == "true" ]]; then
-    curl_args+=("--form" "run_env[debug]=$DEBUG")
+    curl_args+=("--form" "run_env[debug]=\"$DEBUG\"")
   fi
 
   if [[ -n "$PLUGIN_VERSION" ]]; then
-    curl_args+=("--form" "run_env[version]=$PLUGIN_VERSION")
+    curl_args+=("--form" "run_env[version]=\"$PLUGIN_VERSION\"")
   fi
 
   if [[ "$ANNOTATE" != "false" ]]; then

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -220,7 +220,7 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
 
   assert_success
   assert_output --partial "curl success"
-  assert_output --partial "run_env[version]=some-commit-id"
+  assert_output --partial "run_env[version]=\"some-commit-id\""
 }
 
 @test "Follow links option enabled adds find option" {


### PR DESCRIPTION
Fixes https://github.com/buildkite-plugins/test-collector-buildkite-plugin/issues/67

When the `$BUILDKITE_MESSAGE` environment variable contains parentheses (e.g. `(TEST) Message`), the name of the run is being reported incorrectly to Buildkite Test Analytics. 

Surrounding all of the environment variables expansions with quotes fixes this issue.

See the screenshot below for before and after
<img width="1262" alt="Screenshot 2024-01-19 at 10 29 21 am" src="https://github.com/buildkite-plugins/test-collector-buildkite-plugin/assets/89366108/78b092df-a7ac-46fd-99a2-fd833addbe24">
