### PR TITLE
Test Collector Plugin Issue  - error parsing report url

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ The number of concurrent file uploads to perform to the Buildkite analytics API.
 
 Default value: `1`
 
+## Requirements
+
+This plugin requires `jq` for parsing JSON data. If `jq` is not found on the agent, `sed` will be used as a fallback. Ensure that `sed` is also available to handle scenarios where `jq` cannot be used.
+
+## Fallback Behavior
+
+If `jq` is unavailable, the plugin will attempt to parse the results using `sed`. This ensures that the plugin remains functional even if the preferred JSON parser is missing.
+
 ## Examples
 
 ### Upload a JUnit file

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -73,16 +73,22 @@ save-report-url() {
     echo "Could not get the tests report URL from $json_file. File not found."
     return
   fi
-  # Could be easier with jq, but we don't want to require it
+
   if which jq >/dev/null; then
-      echo "Using jq to parse the report URL"
-      report_url=$(jq -r '.run_url' "${json_file}")
+    echo "Using jq to parse the report URL"
+    report_url=$(jq -r '.run_url' "${json_file}" 2>&1) # Capture stderr for error reporting
+    if [[ "$report_url" == "null" || "$report_url" == "" ]]; then
+      echo "jq parsing failed with the message: $report_url"
+      echo "Contents of $json_file:"
+      cat "$json_file"
+      return
+    fi
   else
-      echo "Not using jq to parse the report URL"
-      report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
+    echo "jq not installed, attempting to parse with sed"
+    report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
   fi
 
-  if [ "$report_url" == "null" ]; then
+  if [[ "$report_url" == "null" || "$report_url" == "" ]]; then
     echo "Could not get the tests report URL from $json_file. 'run_url' property not found."
     return
   fi

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -77,7 +77,7 @@ save-report-url() {
   if which jq >/dev/null; then
     echo "Using jq to parse the report URL"
     report_url=$(jq -r '.run_url' "${json_file}" 2>&1) # Capture stderr for error reporting
-    if [[ "$report_url" == "null" || "$report_url" == "" ]]; then
+    if [[ "$report_url" == "null" || "$report_url" == "" || "$report_url" =~ "parse error" ]]; then
       echo "jq parsing failed with the message: $report_url"
       echo "Contents of $json_file:"
       cat "$json_file"
@@ -86,15 +86,22 @@ save-report-url() {
   else
     echo "jq not installed, attempting to parse with sed"
     report_url=$(sed 's/.*"run_url" *: *"\([^"]*\)".*/\1/g' "${json_file}")
+    if [[ "$report_url" == "null" || "$report_url" == "" ]]; then
+      echo "sed parsing failed, no valid URL extracted."
+      echo "Contents of $json_file:"
+      cat "$json_file"
+      return
+    fi
   fi
 
-  if [[ "$report_url" == "null" || "$report_url" == "" ]]; then
-    echo "Could not get the tests report URL from $json_file. 'run_url' property not found."
+  if [ -z "$report_url" ]; then
+    echo "No report URL found or extracted. Unable to save."
     return
   fi
 
   echo "$report_url" >> "$REPORT_URLS_FILE"
 }
+
 
 # Uploads files to the Test Analytics API
 #

--- a/tests/fixtures/response_missing_url.json
+++ b/tests/fixtures/response_missing_url.json
@@ -1,0 +1,1 @@
+{"id": "2","run_id": "2","queued": 130,"skipped": 0,"errors": []}

--- a/tests/fixtures/response_null_url.json
+++ b/tests/fixtures/response_null_url.json
@@ -1,0 +1,1 @@
+{"id": "4","run_id": "4","queued": 150,"skipped": 0,"errors": [],"run_url": null}


### PR DESCRIPTION
**_Error Output Handling:_**
   - Initial Version: Did not handle the stderr output from jq, which means if jq encountered an error during parsing, the error message wouldn't be captured or displayed.
   - Final-my-Version: Captures and echoes stderr output from jq. This includes parsing errors like the one encountered in the issue (e.g., "Invalid numeric literal"). If jq fails to parse the run_url or returns an empty or "null" string, it now outputs an error message and the contents of the JSON file being parsed.
**_Detailed Debugging Information:_**
   - Initial Version: Lacked detailed error messages and debugging information. If the run_url was "null" or parsing failed silently, the script would merely state that the URL property was not found without providing additional context.
   - Final-my-Version: Provides a more detailed debugging approach by including a specific error message from jq when it fails and by printing the contents of the JSON file. This helps in understanding what wennt wrong by showing the actual data that was supposed to be parsed.
_**Conditional Parsing with sed:**_
   - Initial Version: Used sed as a fallback without any error output or handling if jq was not installed.
   - Final-my-Version: Continues to use sed as a fallback but now includes a check after its use to ensure that if sed also fails to find or parse the run_url, a specific error message is outputted.
   
   
(fixes #63)

