### PR TITLE
Minor fixes

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -190,7 +190,7 @@ find_and_upload() {
 
         for index in "${!uploads_in_progress[@]}"; do
           # Note: kill -0 does not kill the pid, it provides a *nix compatible way to test the pid is responding.
-          if ! kill -0 "${uploads_in_progress[index]}" > /dev/null; then
+          if ! kill -0 "${uploads_in_progress[index]}" > /dev/null 2>&1; then
             unset 'uploads_in_progress[index]'
           elif [[ "$iterations_waited" -gt $TIMEOUT ]]; then
             echo "Upload '${uploads_in_progress[index]}' has been running for more than '${TIMEOUT}' seconds, killing it"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -47,7 +47,8 @@ fi
 # Creates the annotations with all the report URLs
 annotation-link() {
   local json_file="$1"
-  mapfile -t REPORT_URLS < <(sort "${json_file}" | uniq)
+  REPORT_URLS=()
+  while IFS= read -r line; do REPORT_URLS+=("${line}"); done < <(sort "${json_file}" | uniq)
 
   local REPORTS=""
   REPORT_COUNT=1


### PR DESCRIPTION
Two minor fixes:
* redirect `kill` output on standard error to standard output (closes #73)
* removes `mapfile` as a dependency by reading the URLs of the files into an array using standard bash (closes #75)