### PR TITLE
README: remove "bk local" suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,7 @@ steps:
 
 ## ⚒ Developing
 
-You can use the [bk cli](https://github.com/buildkite/cli) to run the [pipeline](buildkite.yaml) locally:
-
-```bash
-bk local run
-```
-
-Or if you want to run just the tests, you can use the docker [Plugin Tester](https://github.com/buildkite-plugins/buildkite-plugin-tester):
+To run the tests, you can use the docker [Plugin Tester](https://github.com/buildkite-plugins/buildkite-plugin-tester):
 
 ```bash
 docker run --rm -ti -v "${PWD}":/plugin buildkite/plugin-tester:latest


### PR DESCRIPTION
The "Developing" section suggests running the pipeline locally using the `bk local run` command. 

However, `bk local` is no longer available in the CLI - see https://github.com/buildkite/cli/issues/79#issuecomment-2360090530 

This change removes that suggestion.