### PR TITLE
Introduce `tags` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ steps:
   - label: "🔨 Test"
     command: "make test"
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files: "test/junit-*.xml"
           format: "junit"
 ```
@@ -129,7 +129,7 @@ steps:
   - label: "🔨 Test"
     command: "make test"
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files:
             - "test-data-*.json"
           format: "json"
@@ -151,7 +151,7 @@ steps:
   - label: "🔍 Test Analytics"
     command: buildkite-agent artifact download "tests-*.xml" .
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files: "tests-*.xml"
           format: "junit"
 ```
@@ -165,7 +165,7 @@ steps:
   - label: "🔨 Test"
     command: "make test"
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files: "test-data-*.json"
           format: "json"
           branches: "-qa$"
@@ -178,7 +178,7 @@ steps:
   - label: "🔨 Test"
     command: "make test"
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files: "test-data-*.json"
           format: "json"
           exclude-branches: "^legacy$"
@@ -191,7 +191,7 @@ steps:
   - label: "🔨 Test"
     command: "make test"
     plugins:
-      - test-collector#v1.10.1:
+      - test-collector#v1.10.2:
           files: "test-data-*.json"
           format: "json"
           branches: "^stage-"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ This should allow you to use a special exit code to soft-fail on when no files t
 
 Default value: `1`
 
+#### `tags` (array of strings)
+
+A list of tags to apply to all test results in the upload, in the format `key=value`.
+
+For example:
+
+```yaml
+tags:
+  - "arch=arm64"
+  - "language.version=1.2.3"
+```
+
 #### `timeout` (number)
 
 Maximum number of seconds to wait for each file to upload before timing out.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These are all the options available to configure this plugin's behaviour.
 
 One or more patterns of files to upload to Test Analytics, relative to the root of the searching path (`./` by default). May contain `*` to match any number of characters of any type (unlike shell expansions, it will match `/` and `.` if necessary). Can be either a single pattern in a string or any number of them in an array.
 
-#### `format` (string)
+#### `format` (string)
 
 Format of the file.
 
@@ -20,7 +20,7 @@ Only the following values are allowed: `junit`, `json`
 
 ### Optional
 
-#### `api-token-env-name` (string)
+#### `api-token-env-name` (string)
 
 Name of the environment variable that contains the Test Analytics API token.
 
@@ -45,7 +45,7 @@ For example:
 
 Important: you may have to be careful to escape special characters like `$` during pipeline upload
 
-#### `debug` (boolean)
+#### `debug` (boolean)
 
 Print debug information to the build output.
 
@@ -78,7 +78,7 @@ This should allow you to use a special exit code to soft-fail on when no files t
 
 Default value: `1`
 
-#### `timeout`(number)
+#### `timeout` (number)
 
 Maximum number of seconds to wait for each file to upload before timing out.
 

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -131,6 +131,22 @@ upload() {
     "--form" "run_env[collector]=test-collector-buildkite-plugin"
   )
 
+  if [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS:-}" ]; then
+    curl_args+=("--form" "$(build_tag_form_field "${BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS}")")
+  elif [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS_0:-}" ]; then
+    prefix="BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS"
+    parameter="${prefix}_0"
+    if [ -n "${!parameter:-}" ]; then
+      i=0
+      parameter="${prefix}_${i}"
+      while [ -n "${!parameter:-}" ]; do
+        curl_args+=("--form" "$(build_tag_form_field "${!parameter}")")
+        i=$((i+1))
+        parameter="${prefix}_${i}"
+      done
+    fi
+  fi
+
   if [[ "$DEBUG" == "true" ]]; then
     curl_args+=("--form" "run_env[debug]=\"$DEBUG\"")
   fi
@@ -152,6 +168,14 @@ upload() {
   fi
 
   curl "${curl_args[@]}" -H @<(printf 'Authorization: Token token=\"%s\"\n' "${TOKEN_VALUE}")
+}
+
+# input: "key=value"
+# output: "tags[key]=value"
+build_tag_form_field() {
+  local key="${1%%=*}" # longest matching trailing pattern deleted; keep the part before the first "="
+  local value="${1#*=}" # shortest matching leading pattern deleted; keep the part after the first "="
+  echo "tags[$key]=$value"
 }
 
 # Runs the whole plugin logic for a particular find pattern

--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -135,6 +135,38 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   unstub curl
 }
 
+@test "Single tag from string" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS="hello=world"
+
+  stub curl \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form tags[hello]=world \* -H \* : echo 'curl success'"
+
+  run "$PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+
+  unstub curl
+}
+
+@test "Multiple tags from array" {
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS_0="hello=world"
+  export BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS_1="foo=bar=baz"
+  unset BUILDKITE_PLUGIN_TEST_COLLECTOR_TAGS
+
+  stub curl \
+    "-X POST --silent --show-error --max-time 30 --form format=junit ${COMMON_CURL_OPTIONS} --form tags[hello]=world --form tags[foo]=bar=baz \* -H \* : echo 'curl success'"
+
+  run "$PWD/hooks/pre-exit"
+
+  assert_success
+  assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
+  assert_output --partial "curl success"
+
+  unstub curl
+}
+
 @test "Debug true prints the curl info w/o token" {
   export BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG="true"
 


### PR DESCRIPTION
Allow `tags` to be specified for an upload; they will propagate onto all the test results (executions) within that upload.

Example usage, adding `arch` and `language.version` tags:

```yaml
steps:
  - label: "🔨 Test"
    command: "make test"
    plugins:
      - test-collector#v1.10.2:
          files: "test/junit-*.xml"
          format: "junit"
          tags:
            - "arch=arm64"
            - "language.version=1.2.3"
```