### PR TITLE
`use-triggered-from` boolean: links upload to triggering build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Only the following values are allowed: `junit`, `json`
 
 ### Optional
 
+#### `annotation-link`(boolean)
+
+Adds an annotation to the build run with a link to the uploaded report.
+
+Default value: `false`
+
 #### `api-token-env-name` (string)
 
 Name of the environment variable that contains the Test Engine API token.
@@ -96,17 +102,17 @@ Maximum number of seconds to wait for each file to upload before timing out.
 
 Default value: `30`
 
-#### `annotation-link`(boolean)
-
-Adds an annotation to the build run with a link to the uploaded report.
-
-Default value: `false`
-
 #### `upload-concurrency`(number)
 
 The number of concurrent file uploads to perform to the Buildkite Test Engine API.
 
 Default value: `1`
+
+#### `use-triggered-from` (boolean)
+
+Uses the `BUILDKITE_TRIGGERED_FROM_…` environment variables to attribute the uploaded tests to the build that triggered this one.
+
+Default value: `false`
 
 ## Requirements
 
@@ -153,7 +159,7 @@ You can also use build artifacts generated in a previous step:
 
 ```yaml
 steps:
-  # Run tests and upload 
+  # Run tests and upload
   - label: "🔨 Test"
     command: "make test --junit=tests-N.xml"
     artifact_paths: "tests-*.xml"

--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -2,7 +2,7 @@ steps:
   - label: ":shell: Shellcheck"
     plugins:
       - shellcheck#v1.4.0:
-         files: hooks/**
+          files: ["lib/**", "hooks/**"]
 
   - label: ":sparkles:"
     plugins:

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
 TOKEN_ENV_NAME="${BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME:-BUILDKITE_ANALYTICS_TOKEN}"
 FORMAT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_FORMAT:-}"
 TIMEOUT="${BUILDKITE_PLUGIN_TEST_COLLECTOR_TIMEOUT:-30}"
@@ -103,7 +108,6 @@ save-report-url() {
   echo "$report_url" >> "$REPORT_URLS_FILE"
 }
 
-
 # Uploads files to the Buildkite Test Engine API
 #
 # Upload failures should not fail the build, and should have a sensible timeout,
@@ -113,6 +117,21 @@ upload() {
   local file="$3"
   local format="$2"
 
+  local key="$BUILDKITE_BUILD_ID"
+  local url="$BUILDKITE_BUILD_URL"
+  local number="$BUILDKITE_BUILD_NUMBER"
+  local job_id="$BUILDKITE_JOB_ID"
+
+  if [[
+    ${BUILDKITE_PLUGIN_TEST_COLLECTOR_USE_TRIGGERED_FROM:-false} != "false" &&
+    -n $BUILDKITE_TRIGGERED_FROM_BUILD_ID
+  ]]; then
+    key="$BUILDKITE_TRIGGERED_FROM_BUILD_ID"
+    url=$(infer_triggered_from_build_url)
+    number="$BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER"
+    job_id=""
+  fi
+
   local curl_args=(
     "-X" "POST"
     "--silent"
@@ -121,12 +140,12 @@ upload() {
     "--form" "format=${format}"
     "--form" "data=@\"$file\""
     "--form" "run_env[CI]=buildkite"
-    "--form" "run_env[key]=\"$BUILDKITE_BUILD_ID\""
-    "--form" "run_env[url]=\"$BUILDKITE_BUILD_URL\""
+    "--form" "run_env[key]=\"$key\""
+    "--form" "run_env[url]=\"$url\""
     "--form" "run_env[branch]=\"$BUILDKITE_BRANCH\""
     "--form" "run_env[commit_sha]=\"$BUILDKITE_COMMIT\""
-    "--form" "run_env[number]=\"$BUILDKITE_BUILD_NUMBER\""
-    "--form" "run_env[job_id]=\"$BUILDKITE_JOB_ID\""
+    "--form" "run_env[number]=\"$number\""
+    "--form" "run_env[job_id]=\"$job_id\""
     "--form" "run_env[message]=\"$BUILDKITE_MESSAGE\""
     "--form" "run_env[collector]=test-collector-buildkite-plugin"
   )

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,28 @@
+# Infer the URL of the build that triggered this one.
+# BUILDKITE_BUILD_URL has the scheme and host (generally https://buildkite.com).
+# BUILDKITE_ORGANIZATION_SLUG is assumed to be unchanged (no cross-org triggers).
+# BUILDKITE_TRIGGERED_FROM_... has other details.
+# The /{org}/{pipeline}/builds/{number} path is assumed to be stable (decade+).
+infer_triggered_from_build_url() {
+  if [[
+    -z $BUILDKITE_BUILD_URL ||
+    -z $BUILDKITE_ORGANIZATION_SLUG ||
+    -z $BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG ||
+    -z $BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER
+  ]]; then
+    # fall back to the current build URL
+    echo "$BUILDKITE_BUILD_URL"
+    return
+  fi
+
+  local scheme=${BUILDKITE_BUILD_URL%%://*}
+  local host_onwards=${BUILDKITE_BUILD_URL#*://}
+  local host=${host_onwards%%/*}
+
+  printf "%s://%s/%s/%s/builds/%d" \
+    "$scheme" \
+    "$host" \
+    "$BUILDKITE_ORGANIZATION_SLUG" \
+    "$BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG" \
+    "$BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,8 @@ requirements:
   - curl
 configuration:
   properties:
+    annotation-link:
+      type: boolean
     api-token-env-name:
       type: string
     api-url:
@@ -37,10 +39,10 @@ configuration:
         type: string
     timeout:
       type: integer
-    annotation-link:
-      type: boolean
     upload-concurrency:
       type: integer
+    use-triggered-from:
+      type: boolean
   required:
     - files
     - format

--- a/tests/use-triggered-build.bats
+++ b/tests/use-triggered-build.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# To debug stubs, uncomment these lines:
+# export CURL_STUB_DEBUG=/dev/tty
+# export GIT_STUB_DEBUG=/dev/tty
+
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+
+  . "lib/shared.bash"
+
+  # Build env
+  export BUILDKITE_BRANCH="a-branch"
+  export BUILDKITE_BUILD_ID="a-uuid"
+  export BUILDKITE_BUILD_NUMBER="123"
+  export BUILDKITE_BUILD_URL="https://buildkite.com/buildkite-plugins/test-collector-buildkite-plugin/builds/123"
+  export BUILDKITE_COMMIT="a-commit"
+  export BUILDKITE_JOB_ID="fc946849-b88b-4c67-9611-a50924a57a3c"
+  export BUILDKITE_MESSAGE="A message"
+  export BUILDKITE_ORGANIZATION_SLUG="buildkite-plugins"
+}
+
+@test "With triggered_from data" {
+  export BUILDKITE_TRIGGERED_FROM_BUILD_ID="triggered-from-uuid"
+  export BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER="456"
+  export BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG="upstream"
+
+  run infer_triggered_from_build_url
+
+  assert_success
+  assert_output "https://buildkite.com/buildkite-plugins/upstream/builds/456"
+}
+
+@test "Without triggered_from data falls back to current build URL" {
+  run infer_triggered_from_build_url
+
+  assert_success
+  assert_output "https://buildkite.com/buildkite-plugins/test-collector-buildkite-plugin/builds/123"
+}


### PR DESCRIPTION
Introduce a `use-triggered-from: true` boolean option, which uses the `BUILDKITE_TRIGGERED_FROM_…` [environment variables](https://buildkite.com/docs/pipelines/configure/environment-variables#BUILDKITE_TRIGGERED_FROM_BUILD_ID) to attribute the uploaded tests to the build that triggered the one performing the upload.

This is useful when the tests are run in one build, and their results (e.g. a `junit.xml` file) are uploaded by a separate triggered build. By default, those tests would incorrectly appear to Test Engine as running within the _triggered_ build that uploaded them, and so they would not be shown in the UI of the _triggering_ build that actually ran them.

It's not possible to link tests to their specific jobs within the triggering build; that information is not available. So, it's still preferred to upload test results from the same build that runs the tests.

Related:
- https://buildkite.com/docs/pipelines/configure/environment-variables#BUILDKITE_TRIGGERED_FROM_BUILD_ID