### PR TITLE
`use-triggered-from` tweaks

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -16,6 +16,12 @@ REPORT_URLS_FILE=$(mktemp)
 CURL_RESP_FILE="${CURL_RESP_FILE:-}"
 DEBUG="false"
 
+# these defaults may be overwritten later
+RUN_ENV_KEY="${BUILDKITE_BUILD_ID:-}"
+RUN_ENV_URL="${BUILDKITE_BUILD_URL:-}"
+RUN_ENV_NUMBER="${BUILDKITE_BUILD_NUMBER:-}"
+RUN_ENV_JOB_ID="${BUILDKITE_JOB_ID:-}"
+
 if [[ "${BUILDKITE_PLUGIN_TEST_COLLECTOR_DEBUG:-}" =~ ^(true|on|1|always)$ ]]; then
   DEBUG="true"
 elif [[ "${BUILDKITE_ANALYTICS_DEBUG_ENABLED:-}" =~ ^(true|on|1|always)$ ]]; then
@@ -117,21 +123,6 @@ upload() {
   local file="$3"
   local format="$2"
 
-  local key="$BUILDKITE_BUILD_ID"
-  local url="$BUILDKITE_BUILD_URL"
-  local number="$BUILDKITE_BUILD_NUMBER"
-  local job_id="$BUILDKITE_JOB_ID"
-
-  if [[
-    ${BUILDKITE_PLUGIN_TEST_COLLECTOR_USE_TRIGGERED_FROM:-false} != "false" &&
-    -n $BUILDKITE_TRIGGERED_FROM_BUILD_ID
-  ]]; then
-    key="$BUILDKITE_TRIGGERED_FROM_BUILD_ID"
-    url=$(infer_triggered_from_build_url)
-    number="$BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER"
-    job_id=""
-  fi
-
   local curl_args=(
     "-X" "POST"
     "--silent"
@@ -140,12 +131,12 @@ upload() {
     "--form" "format=${format}"
     "--form" "data=@\"$file\""
     "--form" "run_env[CI]=buildkite"
-    "--form" "run_env[key]=\"$key\""
-    "--form" "run_env[url]=\"$url\""
+    "--form" "run_env[key]=\"$RUN_ENV_KEY\""
+    "--form" "run_env[url]=\"$RUN_ENV_URL\""
     "--form" "run_env[branch]=\"$BUILDKITE_BRANCH\""
     "--form" "run_env[commit_sha]=\"$BUILDKITE_COMMIT\""
-    "--form" "run_env[number]=\"$number\""
-    "--form" "run_env[job_id]=\"$job_id\""
+    "--form" "run_env[number]=\"$RUN_ENV_NUMBER\""
+    "--form" "run_env[job_id]=\"$RUN_ENV_JOB_ID\""
     "--form" "run_env[message]=\"$BUILDKITE_MESSAGE\""
     "--form" "run_env[collector]=test-collector-buildkite-plugin"
   )
@@ -218,7 +209,7 @@ find_and_upload() {
     fi
   else
     declare -a uploads_in_progress=()
-    echo "Uploading '${#matching_files[@]}' files matching '${FILES_PATTERN}'"
+    echo "Uploading ${#matching_files[@]} files matching '${FILES_PATTERN}'"
 
     # needs to be part of else for bash4.3 compatibility
     for file in "${matching_files[@]}"; do
@@ -274,6 +265,22 @@ find_and_upload() {
     wait "${uploads_in_progress[@]}"
   fi
 }
+
+########################################
+
+echo "Buildkite Test Engine"
+
+if [[ ${BUILDKITE_PLUGIN_TEST_COLLECTOR_USE_TRIGGERED_FROM:-} =~ ^(true|on|1|always)$ ]]; then
+  if [[ -n ${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-} ]]; then
+    RUN_ENV_KEY="$BUILDKITE_TRIGGERED_FROM_BUILD_ID"
+    RUN_ENV_URL=$(infer_triggered_from_build_url)
+    RUN_ENV_NUMBER="${BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER:-}"
+    RUN_ENV_JOB_ID="" # the original job ID is unknown
+    echo "use-triggered-from: uploads will be associated with $RUN_ENV_URL"
+  else
+    echo "use-triggered-from is enabled, but BUILDKITE_TRIGGERED_FROM_BUILD_ID is not set" >&2
+  fi
+fi
 
 if [ -n "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES:-}" ]; then
   find_and_upload "${BUILDKITE_PLUGIN_TEST_COLLECTOR_FILES}"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -10,8 +10,8 @@ infer_triggered_from_build_url() {
     -z $BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG ||
     -z $BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER
   ]]; then
-    # fall back to the current build URL
-    echo "$BUILDKITE_BUILD_URL"
+    echo "warning: missing details to infer triggerer-from URL" >&2
+    echo ""
     return
   fi
 

--- a/tests/use-triggered-build.bats
+++ b/tests/use-triggered-build.bats
@@ -7,6 +7,9 @@
 setup() {
   load "$BATS_PLUGIN_PATH/load.bash"
 
+  # run --separate-stderr requires bats 1.5.0 and produces a warning without this declaration
+  bats_require_minimum_version 1.5.0
+
   . "lib/shared.bash"
 
   # Build env
@@ -31,9 +34,10 @@ setup() {
   assert_output "https://buildkite.com/buildkite-plugins/upstream/builds/456"
 }
 
-@test "Without triggered_from data falls back to current build URL" {
-  run infer_triggered_from_build_url
+@test "Without triggered_from data produces empty string" {
+  run --separate-stderr infer_triggered_from_build_url
 
   assert_success
-  assert_output "https://buildkite.com/buildkite-plugins/test-collector-buildkite-plugin/builds/123"
+  output=$stdout assert_output ""
+  output=$stderr assert_output "warning: missing details to infer triggerer-from URL"
 }


### PR DESCRIPTION
Follow-up to #91 which hasn't been released yet:

- only rewrite the upload details once, not once per upload
- log when rewriting: `use-triggered-from: uploads will be associated with $RUN_ENV_URL`
- fall back to empty URL, not current build URL, when required env details are missing

Here's what it looks like when it updates the details:

<img width="1018" height="271" alt="image" src="https://github.com/user-attachments/assets/582b2d6a-e11a-4298-8c56-2bf0013ab056" />


/cc @pzeballos 